### PR TITLE
fix: The footer sections are open in the initial load

### DIFF
--- a/src/components/footer/footer-navigation.tsx
+++ b/src/components/footer/footer-navigation.tsx
@@ -1,12 +1,21 @@
 'use client';
 
-import React, { useState } from 'react';
 import Link from 'next/link';
+import React, { useState } from 'react';
 
 const FooterNavigation: React.FC<{
     sections: { title: string; links: { name: string; href: string }[] }[];
 }> = ({ sections }) => {
-    const [openSections, setOpenSections] = useState<{ [key: string]: boolean }>({});
+    const [openSections, setOpenSections] = useState<{ [key: string]: boolean }>(() =>
+        sections.reduce(
+            (acc, section) => {
+                acc[section.title] = true; // Change to `true` if you want all open by default
+                
+return acc;
+            },
+            {} as { [key: string]: boolean }
+        )
+    );
 
     const toggleSection = (title: string) => {
         setOpenSections((prev) => ({ ...prev, [title]: !prev[title] }));

--- a/src/components/product-listing-page/plp-header/index.tsx
+++ b/src/components/product-listing-page/plp-header/index.tsx
@@ -117,7 +117,7 @@ const PLPHeader = (props: Props) => {
                         Filter
                     </button>
                 </div>
-                <div className='items-per-page hidden w-full md:hidden lg:block xl:block'>
+                <div className='items-per-page hidden w-full lg:contents xl:block'>
                     <select
                         name='page'
                         id='page'
@@ -175,7 +175,7 @@ const PLPHeader = (props: Props) => {
                         </svg>
                     </button>
                 </div>
-                <div className='view-toggle hidden w-full gap-2 md:flex lg:ml-5'>
+                <div className='view-toggle hidden w-full gap-2 md:flex'>
                     <button
                         onClick={() => handleViewChange('grid')}
                         className={`flex h-7 w-16 cursor-pointer items-center gap-1 border p-1 font-bold text-gray-500 ${

--- a/src/components/product-listing-page/product-card/list-view/index.tsx
+++ b/src/components/product-listing-page/product-card/list-view/index.tsx
@@ -54,7 +54,7 @@ const ListView: FC<ProductCardProps> = ({ product }) => {
                         </div>
                     </div>
                     <div className='flex flex-col items-center justify-center'>
-                        <button className='h-8 w-40 rounded-2xl bg-red-600 text-xs font-bold text-white md:h-12 md:w-60 lg:w-70 xl:w-150'>
+                        <button className='h-8 w-40 rounded-2xl bg-red-600 text-xs font-bold text-white md:h-12 md:w-60 lg:w-70 xl:w-100'>
                             CUSTOMIZE SELECTION
                         </button>
                         <p className='mt-2 text-xs text-gray-400'>Sku: {product.sku}</p>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/634ac64a-c89e-4a3f-a4f8-2877e79521b6)
